### PR TITLE
Keyboard gb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/socket.html
 *.pg
 *.toc
 *.vr
+

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ docs/socket.html
 *.toc
 *.vr
 
+# Visual studio
+.vscode/*
+*.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,3 @@ docs/socket.html
 *.pg
 *.toc
 *.vr
-
-# Visual studio
-.vscode/*
-*.code-workspace

--- a/sqlux.ini
+++ b/sqlux.ini
@@ -15,4 +15,4 @@ DEVICE = RAM8,/tmp/.ram8-%x,clean,qdos-like
 WIN_SIZE = max
 FILTER = 1
 FIXASPECT = 1
-
+KBD = DE

--- a/sqlux.ini
+++ b/sqlux.ini
@@ -15,4 +15,4 @@ DEVICE = RAM8,/tmp/.ram8-%x,clean,qdos-like
 WIN_SIZE = max
 FILTER = 1
 FIXASPECT = 1
-KBD = DE
+KBD = GB

--- a/src/SDL2screen.c
+++ b/src/SDL2screen.c
@@ -49,6 +49,14 @@ struct QLcolor QLcolors[16] = {
 
 uint32_t SDLcolors[16];
 
+struct SDLQLMap {
+	SDL_Keycode sdl_kc;
+	int code;
+	int qchar;
+};
+
+static struct SDLQLMap *sdlqlmap;
+static void setKeyboardLayout (void);
 
 /* GIMP RGBA C-Source image dump (sQLuxLogo2.c) */
 
@@ -300,6 +308,9 @@ void QLSDLScreen(void)
 	/* Ensure width and height are always initialised to sane values */
 	w = qlscreen.xres;
 	h = ay;
+
+	/* Initialize keyboard table (doesn't belong here, but was convenient...) */
+	setKeyboardLayout ();
 
 	if (sdl_video_driver != NULL &&
 	    (strcmp(sdl_video_driver, "x11") == 0) ||
@@ -567,13 +578,8 @@ static void SDLQLKeyrowChg(int code, int press)
 	}
 }
 
-struct SDLQLMap {
-	SDL_Keycode sdl_kc;
-	int code;
-	int qchar;
-};
-
-static struct SDLQLMap sdlqlmap[] = { { SDLK_LEFT, 49, 0 },
+static struct SDLQLMap sdlqlmap_DE[] = {
+                                      { SDLK_LEFT, 49, 0 },
 				      { SDLK_UP, 50, 0 },
 				      { SDLK_RIGHT, 52, 0 },
 				      { SDLK_DOWN, 55, 0 },
@@ -589,6 +595,91 @@ static struct SDLQLMap sdlqlmap[] = { { SDLK_LEFT, 49, 0 },
 				      { SDLK_TAB, 19, 0 },
 				      { SDLK_ESCAPE, 51, 0 },
 				      { SDLK_CAPSLOCK, 33, 0},
+				      { SDLK_RIGHTBRACKET, 40, 0 },
+				      { SDLK_5, 58, 0 },
+				      { SDLK_4, 62, 0 },
+				      { SDLK_7, 63, 0 },
+				      { SDLK_LEFTBRACKET, 32, 0 },
+				      { SDLK_z, 22, 0 },
+
+				      { SDLK_PERIOD, 42, 0 },
+				      { SDLK_c, 43, 0 },
+				      { SDLK_b, 44, 0 },
+				      //{ SDLK_BACKQUOTE, 45, 0 },
+
+				      { SDLK_m, 46, 0 },
+				      { SDLK_QUOTE, 47, 0 },
+				      { SDLK_BACKSLASH, 53, 0 },
+				      { SDLK_k, 34, 0 },
+				      { SDLK_s, 35, 0 },
+				      { SDLK_f, 36, 0 },
+				      { SDLK_EQUALS, 37, 0 },
+				      { SDLK_g, 38, 0 },
+				      { SDLK_SEMICOLON, 39, 0 },
+				      { SDLK_l, 24, 0 },
+				      { SDLK_3, 25, 0 },
+				      { SDLK_h, 26, 0 },
+				      { SDLK_1, 27, 0 },
+				      { SDLK_a, 28, 0 },
+				      { SDLK_p, 29, 0 },
+				      { SDLK_d, 30, 0 },
+				      { SDLK_j, 31, 0 },
+				      { SDLK_9, 16, 0 },
+				      { SDLK_w, 17, 0 },
+				      { SDLK_i, 18, 0 },
+				      { SDLK_r, 20, 0 },
+				      { SDLK_MINUS, 69, 0 }, /* minus */
+				      { SDLK_y, 41, 0 },
+				      { SDLK_o, 23, 0 },
+				      { SDLK_8, 8, 0 },
+				      { SDLK_2, 9, 0 },
+				      { SDLK_6, 10, 0 },
+				      { SDLK_q, 11, 0 },
+				      { SDLK_e, 12, 0 },
+				      { SDLK_0, 13, 0 },
+				      { SDLK_t, 14, 0 },
+				      { SDLK_u, 15, 0 },
+				      { SDLK_x, 3, 0 },
+				      { SDLK_v, 4, 0 },
+				      { SDLK_SLASH, 5, 0 },
+				      { SDLK_n, 6, 0 },
+				      { SDLK_COMMA, 7, 0 },
+				      { 180, 45, 0 },       /* accent */
+				      { 228, 47, 0 }, 	    /* Ä OK */
+				      { 246, 103, 0 },       /* Ö OK */
+				      { 252, 32, 0 },       /* Ü OK */
+				      { 94, 53, 0 },       /* < OK */
+				      { 35, 101, 0 },       /* # OK */
+				      { 43, 40, 0 },       /* + OK */
+				      { 223, 21, 0 },       /* ß OK */
+				      { 60, 109, 0 },       /* ^ */
+
+				      /* Accent ^ and \ is 109 */
+
+				      /*
+  {SDLK_Next,-1,220},
+  {SDLK_Prior,-1,212},
+  {SDLK_Home,-1,193},
+  {SDLK_End,-1,201},
+		 */
+				      { 0, 0, 0 } };
+
+static struct SDLQLMap sdlqlmapDefault[] = { { SDLK_LEFT, 49, 0 },
+				      { SDLK_UP, 50, 0 },
+				      { SDLK_RIGHT, 52, 0 },
+				      { SDLK_DOWN, 55, 0 },
+
+				      { SDLK_F1, 57, 0 },
+				      { SDLK_F2, 59, 0 },
+				      { SDLK_F3, 60, 0 },
+				      { SDLK_F4, 56, 0 },
+				      { SDLK_F5, 61, 0 },
+
+				      { SDLK_RETURN, 48, 0 },
+				      { SDLK_SPACE, 54, 0 },
+				      { SDLK_TAB, 19, 0 },
+				      { SDLK_ESCAPE, 51, 0 },
+				      { SDLK_CAPSLOCK, 33, 0 },
 				      { SDLK_RIGHTBRACKET, 40, 0 },
 				      { SDLK_5, 58, 0 },
 				      { SDLK_4, 62, 0 },
@@ -646,6 +737,8 @@ static struct SDLQLMap sdlqlmap[] = { { SDLK_LEFT, 49, 0 },
 		 */
 				      { 0, 0, 0 } };
 
+/* static struct SDLQLMap *sdlqlmap = sdlqlmap_DE; */
+
 void QLSDProcessKey(SDL_Keysym *keysym, int pressed)
 {
 	int i = 0;
@@ -678,13 +771,25 @@ void QLSDProcessKey(SDL_Keysym *keysym, int pressed)
 
 	mod = sdl_altstate | sdl_controlstate << 1 | sdl_shiftstate << 2;
 
+	//printf ("Key pressed with Keysym %d \n", keysym->sym);
+
 	while (sdlqlmap[i].sdl_kc != 0) {
 		if (keysym->sym == sdlqlmap[i].sdl_kc) {
-			if (pressed)
+			if (pressed) {
 				queueKey(mod, sdlqlmap[i].code, 0);
+				// printf ("Sending key %d\n", sdlqlmap[i].code);
+			}
 			SDLQLKeyrowChg(sdlqlmap[i].code, pressed);
 		}
 		i++;
+	}
+}
+
+static void setKeyboardLayout (void) {
+	sdlqlmap = sdlqlmapDefault;
+
+	if (!strcmp("DE", QMD.kbd)) {
+		sdlqlmap = sdlqlmap_DE;
 	}
 }
 

--- a/src/SDL2screen.c
+++ b/src/SDL2screen.c
@@ -16,6 +16,8 @@
 #include "QL_screen.h"
 #include "unixstuff.h"
 
+#define SWAP_SHIFT 0x100
+
 static SDL_Window *ql_window = NULL;
 static uint32_t ql_windowid = 0;
 static SDL_Surface *ql_screen = NULL;
@@ -664,6 +666,80 @@ static struct SDLQLMap sdlqlmap_DE[] = {
 		 */
 				      { 0, 0, 0 } };
 
+static struct SDLQLMap sdlqlmap_GB[] = { { SDLK_LEFT, 49, 0 },
+				      { SDLK_UP, 50, 0 },
+				      { SDLK_RIGHT, 52, 0 },
+				      { SDLK_DOWN, 55, 0 },
+
+				      { SDLK_F1, 57, 0 },
+				      { SDLK_F2, 59, 0 },
+				      { SDLK_F3, 60, 0 },
+				      { SDLK_F4, 56, 0 },
+				      { SDLK_F5, 61, 0 },
+
+				      { SDLK_RETURN, 48, 0 },
+				      { SDLK_SPACE, 54, 0 },
+				      { SDLK_TAB, 19, 0 },
+				      { SDLK_ESCAPE, 51, 0 },
+				      { SDLK_CAPSLOCK, 33, 0 },
+				      { SDLK_RIGHTBRACKET, 40, 0 },
+				      { SDLK_5, 58, 0 },
+				      { SDLK_4, 62, 0 },
+				      { SDLK_7, 63, 0 },
+				      { SDLK_LEFTBRACKET, 32, 0 },
+				      { SDLK_z, 41, 0 },
+
+				      { SDLK_PERIOD, 42, 0 },
+				      { SDLK_c, 43, 0 },
+				      { SDLK_b, 44, 0 },
+				      //{ SDLK_BACKQUOTE, 45, 0 },
+
+				      { SDLK_m, 46, 0 },
+				      { SDLK_QUOTE, 47, 9 },
+				      { SDLK_BACKSLASH, 53, 0 },
+				      { SDLK_k, 34, 0 },
+				      { SDLK_s, 35, 0 },
+				      { SDLK_f, 36, 0 },
+				      { SDLK_EQUALS, 37, 0 },
+				      { SDLK_g, 38, 0 },
+				      { SDLK_SEMICOLON, 39, 0 },
+				      { SDLK_l, 24, 0 },
+				      { SDLK_3, 25, (SWAP_SHIFT | 45) },
+				      { SDLK_h, 26, 0 },
+				      { SDLK_1, 27, 0 },
+				      { SDLK_a, 28, 0 },
+				      { SDLK_p, 29, 0 },
+				      { SDLK_d, 30, 0 },
+				      { SDLK_j, 31, 0 },
+				      { SDLK_9, 16, 0 },
+				      { SDLK_w, 17, 0 },
+				      { SDLK_i, 18, 0 },
+				      { SDLK_r, 20, 0 },
+				      { SDLK_MINUS, 21, 0 },
+				      { SDLK_y, 22, 0 },
+				      { SDLK_o, 23, 0 },
+				      { SDLK_8, 8, 0 },
+				      { SDLK_2, 9, 47 },
+				      { SDLK_6, 10, 0 },
+				      { SDLK_q, 11, 0 },
+				      { SDLK_e, 12, 0 },
+				      { SDLK_0, 13, 0 },
+				      { SDLK_t, 14, 0 },
+				      { SDLK_u, 15, 0 },
+				      { SDLK_x, 3, 0 },
+				      { SDLK_v, 4, 0 },
+				      { SDLK_SLASH, 5, 0 },
+				      { SDLK_n, 6, 0 },
+				      { SDLK_COMMA, 7, 0 },
+				      { SDLK_HASH, (SWAP_SHIFT | 25), 45},
+				      /*
+  {SDLK_Next,-1,220},
+  {SDLK_Prior,-1,212},
+  {SDLK_Home,-1,193},
+  {SDLK_End,-1,201},
+		 */
+				      { 0, 0, 0 } };
+
 static struct SDLQLMap sdlqlmapDefault[] = { { SDLK_LEFT, 49, 0 },
 				      { SDLK_UP, 50, 0 },
 				      { SDLK_RIGHT, 52, 0 },
@@ -737,8 +813,6 @@ static struct SDLQLMap sdlqlmapDefault[] = { { SDLK_LEFT, 49, 0 },
 		 */
 				      { 0, 0, 0 } };
 
-/* static struct SDLQLMap *sdlqlmap = sdlqlmap_DE; */
-
 void QLSDProcessKey(SDL_Keysym *keysym, int pressed)
 {
 	int i = 0;
@@ -771,13 +845,21 @@ void QLSDProcessKey(SDL_Keysym *keysym, int pressed)
 
 	mod = sdl_altstate | sdl_controlstate << 1 | sdl_shiftstate << 2;
 
-	//printf ("Key pressed with Keysym %d \n", keysym->sym);
-
 	while (sdlqlmap[i].sdl_kc != 0) {
 		if (keysym->sym == sdlqlmap[i].sdl_kc) {
 			if (pressed) {
-				queueKey(mod, sdlqlmap[i].code, 0);
-				// printf ("Sending key %d\n", sdlqlmap[i].code);
+				/* Shift generates another key code? */
+				int code = ((!sdl_shiftstate) ||
+				            (!sdlqlmap[i].qchar)) ?
+					    sdlqlmap[i].code :
+					    sdlqlmap[i].qchar;
+
+				/* Code requires a change in shift state? */
+				if (SWAP_SHIFT & code) {
+					code &= ~SWAP_SHIFT;
+					mod ^= (0x1 << 2);
+				}
+				queueKey(mod, code, 0);
 			}
 			SDLQLKeyrowChg(sdlqlmap[i].code, pressed);
 		}
@@ -790,6 +872,9 @@ static void setKeyboardLayout (void) {
 
 	if (!strcmp("DE", QMD.kbd)) {
 		sdlqlmap = sdlqlmap_DE;
+	}
+	else if (!strcmp("GB", QMD.kbd)) {
+		sdlqlmap = sdlqlmap_GB;
 	}
 }
 

--- a/uqlx_cfg.c
+++ b/uqlx_cfg.c
@@ -47,6 +47,7 @@ QMDATA QMD = {
 	.no_patch = 0, /* no_patch, default off */
 	.aspect = 0, /* fix aspect ration */
 	.filter = 0, /* enable bilinear filter */
+	.kbd = "US", /* Default keyboard layout (American English) */
 };
 
 static char *strim(char *s)
@@ -332,6 +333,7 @@ static PARSELIST pl[] = {
 	{ "FIXASPECT", (PVFV)pInt2, offsetof(QMDATA, aspect) },
 	{ "FILTER", (PVFV)pInt2, offsetof(QMDATA, filter) },
 	{ "RESOLUTION", (PVFV)pString, offsetof(QMDATA, resolution), 63 },
+	{ "KBD", (PVFV)pString, offsetof(QMDATA, kbd), 2 },
 	{ NULL, NULL },
 };
 

--- a/uqlx_cfg.h
+++ b/uqlx_cfg.h
@@ -44,7 +44,7 @@ typedef struct {
 	short no_patch;
 	short aspect;
 	short filter;
-	char kbd[2];
+	char kbd[3];	// Two characters + null terminator
 } QMDATA;
 
 #define QMFILE "~/.uqlxrc"

--- a/uqlx_cfg.h
+++ b/uqlx_cfg.h
@@ -44,6 +44,7 @@ typedef struct {
 	short no_patch;
 	short aspect;
 	short filter;
+	char kbd[2];
 } QMDATA;
 
 #define QMFILE "~/.uqlxrc"


### PR DESCRIPTION
This pull request does the following:
1) Includes the code submitted to the QL Forum by member _tofro_, to add support for a German keyboard. I've made a couple of changes, one to change the default keyboard type from GB to US, the other to increase the storage space to hold the null terminator
2) Extends the code submitted by _tofro_ to provide an `SDLQLMap` structure for GB keyboards
3) Uses the unused `qchar` field to specify a different key code to be sent when the shift (but not the control) key is pressed, this allows mapping of " £ and @
4) Maps the "#" key, instead of the back quote key (top left key). Generates a shift when # is pressed.
5) Removes the shift when £ is pressed, as £ is a primary key on the QL GB keyboard
6) Maps the delete key and sends control right
7) The GB keyboard is selected by adding `KBD = GB` to `sqlux.ini`

I've built and run under Linux, Windows 10 (mingw) and a Raspberry Pi4 (32-bit OS). 