### PR TITLE
Speed

### DIFF
--- a/docs/sqlux.md
+++ b/docs/sqlux.md
@@ -189,7 +189,7 @@ CPU_HOG = 1
 ```
 
 `FAST_START`
-Set to 1 if you want to skip the usual RAM test(default), or set it to 0 if you want to enjoy the Ram test pattern.
+Set to 1 if you want to skip the usual RAM test(default), or set it to 0 if you want to enjoy the Ram test pattern. Has no effect with the Minerva ROM
 
 ```
 FAST_START = 1
@@ -298,6 +298,12 @@ Select the keyboard language.
 KBD = DE
 ```
 
+`SPEED`
+Sets the execution speed of the emulator. Useful when running software that was written for an original QL. A value of 1 approximates to the speed of an orginal QL. Larger values map to multiples of the original QL speed. Specified as a floating point number, so small adjustments can be made if required. Defaults to 0.0 (maximum speed). When running at original speed a faster start-up is achieved by using the JS ROM and setting FAST_START to 1.
+
+```
+SPEED = 1.5
+```
 and here is the example of an actual sqlux.ini file. You will find more recent versions of it with every sQLux distribution.
 
 ```

--- a/include/SDL2screen.h
+++ b/include/SDL2screen.h
@@ -24,6 +24,7 @@ extern unsigned int sdl_keyrow[8];
 extern int sdl_shiftstate,sdl_controlstate, sdl_altstate;
 
 extern SDL_atomic_t doPoll;
+extern SDL_sem* sem50Hz;
 
 #endif
 

--- a/src/SDL2screen.c
+++ b/src/SDL2screen.c
@@ -34,6 +34,8 @@ static char ql_fullscreen = false;
 SDL_atomic_t doPoll;
 SDL_atomic_t screenUpdate;
 
+SDL_sem* sem50Hz = NULL;
+
 struct QLcolor {
 	int r;
 	int g;
@@ -394,6 +396,7 @@ void QLSDLScreen(void)
 					  QLcolors[i].g, QLcolors[i].b);
 
 	SDL_AtomicSet(&doPoll, 0);
+	sem50Hz = SDL_CreateSemaphore(0);
 	fiftyhz_timer = SDL_AddTimer(20, QLSDL50Hz, NULL);
 }
 
@@ -993,6 +996,10 @@ Uint32 QLSDL50Hz(Uint32 interval, void *param)
 	SDL_AtomicSet(&doPoll, 1);
 
 	schedCount = 0;
+
+	if (sem50Hz && !SDL_SemValue(sem50Hz)) {
+		SDL_SemPost(sem50Hz);
+	}
 
 	return interval;
 }

--- a/unixstuff.c
+++ b/unixstuff.c
@@ -926,6 +926,8 @@ void uqlxInit()
 	if (!script)
 		QLSDLScreen();
 
+	if (V1 && (QMD.speed > 0)) printf("Speed %.1f\n",QMD.speed);
+
 #ifdef TRACE
 	TraceInit();
 #endif
@@ -986,12 +988,26 @@ Cond CPUWork(void)
 #endif
 {
 	int scrchange, i;
+	int loop = 0;
+
+	int speed = (int)(QMD.speed * 20);
+	speed = (speed >= 0) && (sem50Hz != NULL) ? speed : 0;
 
 #ifndef XAW
 exec:
 #endif
+	if (!speed) {
+		ExecuteChunk(3000);
+	}
+	else {
+		ExecuteChunk(300);
+		++loop;
 
-	ExecuteChunk(3000);
+		if (loop >= speed) {
+			SDL_SemWait(sem50Hz);
+			loop = 0;
+		}
+	}
 
 #ifdef UX_WAIT
 	if (run_reaper)

--- a/uqlx_cfg.c
+++ b/uqlx_cfg.c
@@ -47,6 +47,7 @@ QMDATA QMD = {
 	.no_patch = 0, /* no_patch, default off */
 	.aspect = 0, /* fix aspect ration */
 	.filter = 0, /* enable bilinear filter */
+	.speed = 0, /* Fastest speed */
 	.kbd = "US", /* Default keyboard layout (American English) */
 };
 
@@ -311,6 +312,11 @@ static void pInt2(short *p, char *s, ...)
 	*p = (short)strtol(s, NULL, 0);
 }
 
+static void pFloat(float *p, char *s, ...)
+{
+	*p = (float)strtod(s, NULL);
+}
+
 static PARSELIST pl[] = {
 	{ "DEVICE", (PVFV)ParseDevs, offsetof(QMDATA, qdev) },
 	{ "ROMIM", (PVFV)pString, offsetof(QMDATA, romim), 63 },
@@ -333,6 +339,7 @@ static PARSELIST pl[] = {
 	{ "FIXASPECT", (PVFV)pInt2, offsetof(QMDATA, aspect) },
 	{ "FILTER", (PVFV)pInt2, offsetof(QMDATA, filter) },
 	{ "RESOLUTION", (PVFV)pString, offsetof(QMDATA, resolution), 63 },
+	{ "SPEED", (PVFV)pFloat, offsetof(QMDATA, speed) },
 	{ "KBD", (PVFV)pString, offsetof(QMDATA, kbd), 2 },
 	{ NULL, NULL },
 };

--- a/uqlx_cfg.h
+++ b/uqlx_cfg.h
@@ -44,6 +44,7 @@ typedef struct {
 	short no_patch;
 	short aspect;
 	short filter;
+	float speed;
 	char kbd[3];	// Two characters + null terminator
 } QMDATA;
 


### PR DESCRIPTION
This pull requests allowed a user to configure the speed of the emulator, by adding a line to the config file. 
SPEED = X.Y where X.Y is a float, and 1.0 equates to the speed of an original QL.  
The speed is limited by waiting for a semaphore triggered by the 50Hz callback. By default everything runs at full speed. When the speed is set to 1.0 a couple of benchmarks (bogomips, qsbb) are a good match to figures for the original QL.
I've built under 64 bit Linux, 32-bit Raspberry Pi and 64 bit Mingw Windows.
I've added a couple of lines of docs to sqlux.md