### PR TITLE
Remove isreg flag for (An) addressing mode

### DIFF
--- a/memaccess.c
+++ b/memaccess.c
@@ -145,7 +145,6 @@ rw8 ModifyAtEA_b(ashort mode,ashort r)
 		dest = (Ptr)(&reg[r]) + RBO;
 		return *((w8 *)dest);
 	case 2:
-		isreg = 1;
 		addr = aReg[r];
 		break;
 	case 3:


### PR DESCRIPTION
In byte mode, (An) addressing mode was erroneously tagged as a register access within ModifyAtEA_b. This meant that WriteByte was not called in the corresponding RewriteEA_b. This can lead to modifications to screen and hardware memory being missed.
This change removes the line that sets the isreg flag. Case 2 for ModifyAtEA_b now aligns with case 2 for ModifyAtEA_w and ModifyAtEA_l