### PR TITLE
Fix no sound

### DIFF
--- a/QL_sound.c
+++ b/QL_sound.c
@@ -104,7 +104,6 @@ bool initSound(int volume) {
 		if (V1) {
 			printf("Failed to open audio device: %s\n", SDL_GetError());
 		}
-		SDL_Quit();
 		sound_enabled = false;
 		return sound_enabled;
 	}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Run the mingw64 environment
 Install the toolchain and SDL2
 
     pacman -Sy mingw-w64-x86_64-toolchain
+    pacman -Sy mingw-w64-x86_64-cmake
     pacman -Sy mingw-w64-x86_64-SDL2
 
 Create the build directory and compile


### PR DESCRIPTION
I found two issues when building sQLux on a new Windows install on hardware that had no sound output.
1) sQLux hangs if sound is selected, but no valid sound output exists. This was due to me calling SDL_Quit() if an error was detected initialising sound. Removing this call fixes this.
2) cmake is not installed as part of the basic mingw toolchain install. I've added a line to the ReadMe to explicitly install cmake.