### PR TITLE
static Windows C++ lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ endif ()
 
 if (SDL2_LIBRARIES)
     if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-        target_link_libraries(sqlux -Wl,-Bstatic -L/usr/local/${TOOLCHAIN_PREFIX}/lib -lmingw32 -lSDL2main -lSDL2 -Wl,-Bdynamic -lwsock32 -lwinmm -lsetupapi -limm32 -lversion -static-libgcc)
+        target_link_libraries(sqlux -Wl,-Bstatic -L/usr/local/${TOOLCHAIN_PREFIX}/lib -lmingw32 -lSDL2main -lSDL2 -lwsock32 -lwinmm -lsetupapi -limm32 -lversion -static-libgcc -static-libstdc++)
     else()
         target_link_libraries(sqlux ${SDL2_LIBRARIES})
     endif()


### PR DESCRIPTION
Statically link C++, to remove dependency on C++ dll for win 64