### PR TITLE
Checkmem

### DIFF
--- a/QDisk.c
+++ b/QDisk.c
@@ -25,6 +25,7 @@
 #include "emudisk.h"
 #include "QDOS.h"
 #include "dummies.h"
+#include "memaccess.h"
 
 #include "SDL2screen.h"
 
@@ -1848,9 +1849,6 @@ OSErr QDiskIO(struct mdvFile *f, short op)
 			aReg[1] = to;
 			ChangedMemory(from, to);
 		}
-
-		/* Update Screen in case we loaded to it */
-		QLSDLUpdatePixelBuffer();
 		break;
 	case 0x49: /* save file from memory */
 		count = reg[2];

--- a/QL_driver.c
+++ b/QL_driver.c
@@ -26,6 +26,7 @@
 #include "unix.h"
 #include "unixstuff.h"
 #include "uqlx_cfg.h"
+#include "memaccess.h"
 #include "QVFS.h"
 
 #define min(_a_, _b_) (_a_ < _b_ ? _a_ : _b_)

--- a/memaccess.c
+++ b/memaccess.c
@@ -10,6 +10,13 @@
 #include "QL_screen.h"
 #include "SDL2screen.h"
 
+void ChangedMemory(uint32_t from, uint32_t to)
+{
+	/* Assumes to >= from */
+	if ((to >= qlscreen.qm_lo) && (from < qlscreen.qm_hi))
+		screenWritten = true;
+}
+
 static void check_screen(uint32_t addr)
 {
 	if ((addr >= qlscreen.qm_lo) && (addr < qlscreen.qm_hi)) {
@@ -31,6 +38,7 @@ static int is_hw(uint32_t addr)
 
 	return 0;
 }
+
 rw8 ReadByte(aw32 addr)
 {
 	addr &= ADDR_MASK;

--- a/memaccess.h
+++ b/memaccess.h
@@ -26,6 +26,8 @@ void rww_acc(int16_t d);
 void RewriteEA_l(int32_t d);
 void rwl_acc(int32_t d);
 
+void ChangedMemory(uint32_t from, uint32_t to);
+
 #define QL_ROM_BASE             0x0000
 #define QL_ROM_SIZE             0xC000
 #define QL_ROM_PORT_BASE        0xC000

--- a/unixstuff.c
+++ b/unixstuff.c
@@ -331,11 +331,6 @@ int toggle_hog(int val)
 	return QMD.cpu_hog;
 }
 
-void ChangedMemory(int from, int to)
-{
-	screenWritten = true;
-}
-
 void usage(char **argv)
 {
 	printf("UQLX release %s:\n\tusage: %s [options] arguments\n", release,

--- a/unixstuff.h
+++ b/unixstuff.h
@@ -11,7 +11,6 @@ void uqlxInit(void);
 int QLRun(void *data);
 long ql2uxtime(long t);
 long ux2qltime(long t);
-void ChangedMemory(int from, int to);
 int qm_fork(void (*cleanup)(), unsigned long id);
 void prep_rtc_emu(void);
 void GetDateTime(int32_t *t);

--- a/uxfile.c
+++ b/uxfile.c
@@ -34,6 +34,7 @@
 #include "unixstuff.h"
 #include "QL_driver.h"
 
+#include "memaccess.h"
 #include "SDL2screen.h"
 
 #include "q-emulator.h"


### PR DESCRIPTION
Check to see if screen memory is written within ChangedMem. 
Move ChangedMem to memory access file (where other screen write checks are made).