### PR TITLE
mingw under linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 find_package(Git)
 
 set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost 1.36.0 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.36.0 REQUIRED COMPONENTS program_options system)
 
 add_custom_target( SubmarineGitVersion
     COMMAND ${CMAKE_COMMAND}

--- a/Init.c
+++ b/Init.c
@@ -4,6 +4,7 @@
 
 
 #ifndef IE_XL
+#include <stdlib.h>
 #include <errno.h>
 
 #include "QL68000.h"

--- a/README.md
+++ b/README.md
@@ -27,16 +27,19 @@ Basic instructions
 Instructions based on debian/ubuntu distro, for other distros you will have to modify as appropriate
 
 Download the SDL2 mingw SDK and adapt the following to your environment/version.
+The SDL2 development libraries can be found [here](https://github.com/libsdl-org/SDL/releases): 
 
-    tar xvf SDL2-devel-2.0.14-mingw.tar.gz
-    cd cd SDL2-2.0.14/
+    tar xvf SDL2-devel-2.0.18-mingw.tar.gz
+    cd SDL2-devel-2.0.18/
     sed -i "s|/opt/local/|/usr/local/|" x86_64-w64-mingw32/lib/cmake/SDL2/sdl2-config.cmake
     sed -i "s|/opt/local/|/usr/local/|" i686-w64-mingw32/lib/cmake/SDL2/sdl2-config.cmake
     sudo mkdir /usr/local/i686-w64-mingw32
     sudo mkdir /usr/local/x86_64-w64-mingw32
     sudo make cross
 
-Now the mingw version of SDL2 is available and we can build sQLux for Win64
+Download, build and install a mingw version of the boost libraries. Instructions are given [here](https://github.com/libmingw-w64/libboost-mingw-w64)  
+   
+Now the mingw versions of SDL2 and boost is available and we can build sQLux for Win64
 
     mkdir mingw
     cd mingw

--- a/src/SqluxOptions.cpp
+++ b/src/SqluxOptions.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
+#include <boost/process/environment.hpp>
 
 extern "C" {
     #include <sys/stat.h>
@@ -19,6 +20,7 @@ namespace emulator
 using namespace std;
 namespace po = boost::program_options;
 namespace po_style = boost::program_options::command_line_style;
+namespace pid = boost::this_process;
 
 static po::variables_map vm;
 
@@ -90,7 +92,7 @@ void deviceInstall(std::vector<string> device)
                 auto hex = fileString.find("%x");
                 if (hex != string::npos) {
                     char tbuf[17];
-                    snprintf(tbuf, 17, "%x", getpid());
+                    snprintf(tbuf, 17, "%x", pid::get_id());
                     fileString.erase(hex, 2);
                     fileString.insert(hex, tbuf);
                 }


### PR DESCRIPTION
Some small changes to code and docs for compilation using mingw under linux.

1. Documented installation of boost for mingw under linux and gave a link to download SDL2
2. The version of Ubuntu mingw boost I used (see link in doc update) was configured to undefine the definitions of pid_t and getpid in SqluxOptions.cpp, so compilation failed. I therefore used the version defined in boost instead (get_id from the boost system library)
3. It also highlighted the need to include stdlib in Init.c (for malloc)
4. Note that the latest version of the mingw SDL libraries produce an invalid windows executable when statically linked [see here](https://github.com/libsdl-org/SDL/issues/6139#issuecomment-1234325699), which is why I used version 2.0.18