### PR TITLE
WebAsm fixes

### DIFF
--- a/QL_boot.c
+++ b/QL_boot.c
@@ -33,7 +33,7 @@
 /*           1: ux_bfd is file handle */
 /*           2: ux_bname is command string */
 
-int boot_init(int);
+int boot_init(int, void *);
 int boot_open(int, void **);
 int boot_test(int, char *);
 void boot_close(int, void *);
@@ -120,7 +120,7 @@ int u_read(struct BOOT_PRIV *p, void *buf, int pno)
 		return qmaperr();
 }
 
-int boot_init(int idx)
+int boot_init(int idx, void * ignored)
 {
 	return 0;
 }

--- a/src/SDL2screen.c
+++ b/src/SDL2screen.c
@@ -351,6 +351,7 @@ void QLSDLScreen(void)
 	    (strcmp(sdl_video_driver, "x11") == 0) ||
 	    (strcmp(sdl_video_driver, "cocoa") == 0) ||
 	    (strcmp(sdl_video_driver, "windows") == 0) ||
+	    (strcmp(sdl_video_driver, "emscripten") == 0) ||
 	    (strcmp(sdl_video_driver, "wayland") == 0) &&
 	    sdl_mode.w >= 800 &&
 	    sdl_mode.h >= 600) {


### PR DESCRIPTION
Fix crash on wasm due to QL_boot.c and QL_driver.c having differing declarations of QL_boot.c::boot_init()

Add emscripten video driver to list of resizable drivers so that wasm container is not forced to full screen.