### PR TITLE
Spanish Keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Now the mingw version of SDL2 is available and we can build sQLux for Win64
 
     mkdir mingw
     cd mingw
-    cmake -DCMAKE_TOOLCHAIN_FILE=../mingw-w64-x86_64.cmake -DCMAKE_PREFIX_PATH=/usr/local/x86_64-w64-mingw32 ..
+    cmake -DCMAKE_TOOLCHAIN_FILE=../Toolchain-mingw-w64-x86_64.cmake -DCMAKE_PREFIX_PATH=/usr/local/x86_64-w64-mingw32 ..
     make
 
 ## Building MinGW on Windows

--- a/docs/sqlux.md
+++ b/docs/sqlux.md
@@ -319,7 +319,7 @@ FIXASPECT = 1
 ```
 
 `KBD`
-Select the keyboard language. Valid options are `GB`, `DE` and `US`. Defaults to `US`.
+Select the keyboard language. Valid options are `GB`, `DE`, `ES` and `US`. Defaults to `US`.
 
 ```
 KBD = DE

--- a/src/emulator_options.c
+++ b/src/emulator_options.c
@@ -56,7 +56,7 @@ struct emuOpts emuOptions[] = {
 {"iorom2", "", "rom in 2nd IO area (Minerva only 0x14000 address)", EMU_OPT_CHAR, 0, NULL},
 {"joy1", "", "1-8 SDL2 joystick index", EMU_OPT_INT, 0, NULL},
 {"joy2", "", "1-8 SDL2 joystick index", EMU_OPT_INT, 0, NULL},
-{"kbd", "", "keyboard language DE, GB, US", EMU_OPT_CHAR, 0, "US"},
+{"kbd", "", "keyboard language DE, GB, ES, US", EMU_OPT_CHAR, 0, "US"},
 {"no_patch", "n", "disable patching the rom", EMU_OPT_INT, 0, NULL},
 {"palette", "", "0 = Full colour, 1 = Unsaturated colours (slightly more CRT like), 2 =  Enable grayscale display", EMU_OPT_INT, 0, NULL},
 {"print", "", "command to use for print jobs", EMU_OPT_CHAR, 0, "lpr"},


### PR DESCRIPTION
Add generic Spanish keyboard support, including generic dead key and Alt Gr handling.
Written for, and tested on, Linux X11 and MS Windows

**Main areas:**
1. Add ES keyboard option for command line and sqlux.ini
2. Add ES keyboard map
3. Split left and right Alt keys, to allow detection of Alt Gr key combinations needed in Spanish
4. Add generic dead key support, which should make supporting other keyboard types easier in the future
5. Handle SDL keycode differences between X11 and MS Windows Spanish keyboards
6. Trivial update to Linux mingw build instructions, found during testing

**Notes:**
1. Extensive testing in Linux by Badaman from QLforum, as a native Spanish user he helped to track down bugs and correct misconceptions I had on how a Spanish keyboard operates. Also tested on Pi OS (X11) and MS Windows.
2. Does not work on Pi OS with SDL2 configured to use Wayland, as currently Wayland does not enable SDL2 to generate key press events for dead keys.
3. To mark the inclusion of Spanish keyboard support Badaman asked if the next sQLux release could be named using a Monty Python Spanish Inquisition theme. The name "Comfy chair" was suggested 