### PR TITLE
Reattach windows console if it exists

### DIFF
--- a/src/SDL2main.c
+++ b/src/SDL2main.c
@@ -87,11 +87,31 @@ void emu_loop() {
     }
 }
 
+#ifdef __WIN32__
+#include <windows.h>
+static void reattach_console(void)
+{
+   // Will succeed if launched from console,
+   // will fail if launched from GUI
+   if (AttachConsole(ATTACH_PARENT_PROCESS))
+   {
+       freopen("CONIN$", "r", stdin);
+       freopen("CONOUT$", "w", stdout);
+       freopen("CONOUT$", "w", stderr);
+   }
+}
+#endif
+
 int main(int argc, char *argv[])
 {
 #if __EMSCRIPTEN__
     wasm_init_storage();
 #endif
+#ifdef __WIN32__
+    // Display output if started from console
+    reattach_console();
+#endif
+
     // set the homedir for the OS first
     SetHome();
 


### PR DESCRIPTION
The use of the SDL build command of -mwindows prevents an extra console window being created when sQLux is started from the GUI. Unfortunately, it also prevents the output of stdout and stderr if sQLux is launched from a MS Windows console.

This change reattaches sQLux to the console, if sQLux is started from the console, so that output can be seen in the console.

It only impacts MS Windows builds. 

It does have some drawbacks - so we may decide to not merge this PR into the load. The drawbacks are:

1. Currently output is seen in Windows if sQLux is launched from an msys2 window. This change will prevent output to an msys2 window. However, end users are much more likely to launch sQLux from an MS Windows console, rather than an msys2 window
2. If sQLux is launched from an MS Windows console, after sQLux terminates, the user needs to press a key in the MS Windows console to return to the command prompt