### PR TITLE
Key warn doc

### DIFF
--- a/QLip.c
+++ b/QLip.c
@@ -60,6 +60,8 @@ static open_arg ip_par[2];
 #ifdef __WIN32__
 int ws2_init = 0;
 WSADATA wsaData;
+#else
+#define SOCKET int
 #endif
 
 int ip_init(int idx, void *p)
@@ -125,7 +127,7 @@ int ip_open(int id, void **priv)
 				struct servent *s;
 
 				if ((h = gethostbyname(host)) != NULL) {
-					int (*func)(int socket, const struct sockaddr *address, socklen_t address_len);
+					int (*func)(SOCKET socket, const struct sockaddr *address, socklen_t address_len);
 
 					s = getservbyname(aport, (dindx & 1) ?
 									 "udp" :

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -20,7 +20,7 @@ git submodule update --init --recursive
 
 ## Building linux
 ```
-cd linux
+cd build
 cmake -DSUPPORT_SHADERS=TRUE ..
 make
 ```

--- a/src/SDL2screen.c
+++ b/src/SDL2screen.c
@@ -54,7 +54,6 @@ typedef enum {
     KEY_ACTION_NONE,
     KEY_ACTION_DIA,
     KEY_ACTION_CIR,
-    KEY_ACTION_GRA,
 } KeyboardAction;
 
 typedef struct DeadKey {
@@ -838,12 +837,11 @@ static struct SDLQLMap_f sdlqlmap_ES[] = {
     { MOD_NONE,     SDLK_PLUS,          (SWAP_SHIFT | QL_EQUAL) }, // +
     { MOD_SHIFT,    SDLK_PLUS,          QL_8 }, // *
     { MOD_NONE,     SDL_DEADKEY_2,      QL_LBRACKET }, // ´
+    { MOD_NONE,     SDL_DEADKEY_1,      QL_RBRACKET }, // `
     { MOD_NONE,     231,                (SWAP_SHIFT | QL_POUND) }, // ç
     { MOD_SHIFT,    231,                (SWAP_CNTRL | QL_H) }, // Ç
     { MOD_WILD,     241,                QL_SEMICOLON }, // ñ Ñ û
     { MOD_WILD,     SDLK_LESS,          QL_SLASH }, // < >
-    { MOD_NONE,     SDL_DEADKEY_1,      QL_RBRACKET }, // `
-    { MOD_SHIFT,    SDL_DEADKEY_1,      QLSH_RBRACKET }, // ^
     { MOD_CTRL,     SDLK_PLUS,          (SWAP_SHIFT | QL_RBRACKET) }, // down arrow
     { MOD_CSFT,     SDLK_PLUS,          QL_LBRACKET }, // Up arrow
     { MOD_CTRL,     231,                QL_QUOTE }, // right arrow
@@ -1023,11 +1021,11 @@ void QLSDProcessKey(SDL_Keysym *keysym, int pressed)
 	{
 		if (pressed)
 		{
-			if ((keysym->sym == SDL_DEADKEY_1) ||
+			if (((keysym->sym == SDL_DEADKEY_1) && sdl_shiftstate) ||
 			    ((keysym->sym == SDL_DEADKEY_2) && sdl_shiftstate))
 			{
 				dkey.id = keysym->sym;
-				dkey.action = (keysym->sym == SDL_DEADKEY_2) ? KEY_ACTION_DIA : sdl_shiftstate ? KEY_ACTION_CIR : KEY_ACTION_GRA;
+				dkey.action = (keysym->sym == SDL_DEADKEY_2) ? KEY_ACTION_DIA : KEY_ACTION_CIR;
 				dkey.ignore = true;
 				return;
 			}
@@ -1106,28 +1104,6 @@ void QLSDProcessKey(SDL_Keysym *keysym, int pressed)
 						break;
 					}
 				}
-				else // Grave
-				{
-					replace_mod = 0x06;
-					switch (keysym->sym)
-					{
-						case SDLK_a:
-							dkey.replace_code = QL_9;
-						break;
-						case SDLK_e:
-							dkey.replace_code = QL_Q;
-						break;
-						case SDLK_i:
-							dkey.replace_code = QL_O;
-						break;
-						case SDLK_o:
-							dkey.replace_code = QL_I;
-						break;
-						case SDLK_u:
-							dkey.replace_code = QL_COMMA;
-						break;
-					}
-				}
 
 				// Need to detect the release of the translated key
 				dkey.id = keysym->sym;
@@ -1145,11 +1121,6 @@ void QLSDProcessKey(SDL_Keysym *keysym, int pressed)
 				{
 					dkey.replace_code = QL_LBRACKET;
 					replace_mod = 0x04;
-				}
-				else
-				{
-					dkey.replace_code = QL_RBRACKET; // `
-					replace_mod = 0x2;
 				}
 			}
 

--- a/uxfile.c
+++ b/uxfile.c
@@ -691,7 +691,7 @@ int QHOpenDir(struct mdvFile *f, int fstype)
 
 #ifdef __WIN32__
 	sqlux_getemppath(sizeof(templ), templ);
-	strncat(templ, "/QDOSXXXXXX", sizeof(templ));
+	strncat(templ, "/QDOSXXXXXX", sizeof(templ)-1);
 	fd = sqlux_mkstemp(templ);
 #else
 	strncpy(templ, template, sizeof(templ));


### PR DESCRIPTION
1. Use mge ROM deadkey for à, è, ì, ò and ù, rather than generate within sQLux. Fixes bug where ù was generating β
2. Fix MS Windows mingw compile warnings
3. Update linux build directory in shader docs