### PR TITLE
Shader fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         if: ${{ github.event.inputs.build_enabled_x86_64 != 'false' }}
         run: |
           echo "############### configuring cmake"
-          cmake -B build/ -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          cmake -B build/ -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DSUPPORT_SHADERS=True
       - name: Build w/ CMake
         if: ${{ github.event.inputs.build_enabled_x86_64 != 'false' }}
         run: |
@@ -233,7 +233,7 @@ jobs:
       - name: Configure CMake
         if: ${{ github.event.inputs.build_enabled_macos != 'false' }}
         run: |
-          cmake -B build/ -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          cmake -B build/ -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DSUPPORT_SHADERS=True
       - name: Build w/ CMake
         if: ${{ github.event.inputs.build_enabled_macos != 'false' }}
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ if(SUPPORT_SHADERS)
   set(DISABLE_GLES_1 "TRUE")
   add_subdirectory(sdl-gpu)
   target_compile_options(SDL_gpu PRIVATE "-w")
+  target_compile_options(SDL_gpu PRIVATE "-Wno-incompatible-pointer-types")
   add_dependencies(sqlux SDL_gpu)
 endif()
 

--- a/include/SDL2screen.h
+++ b/include/SDL2screen.h
@@ -17,6 +17,7 @@ void QLSDLExit(void);
 Uint32 QLSDL50Hz(Uint32 interval, void *param);
 void QLSDLUpdateScreenWord(uint32_t, uint16_t);
 void QLSDLUpdateScreenLong(uint32_t, uint32_t);
+void QLSDLWritePixels(uint32_t *pixelPtr32);
 
 void QLSDLCreatePalette(const SDL_PixelFormat *format);
 void QLSDLCreateIcon(SDL_Window *window);

--- a/src/SDL2main.c
+++ b/src/SDL2main.c
@@ -109,7 +109,10 @@ int main(int argc, char *argv[])
 #endif
 #ifdef __WIN32__
     // Display output if started from console
-    reattach_console();
+    if (!getenv("SQLUX_WIN_DISABLE_CONSOLE_OUTPUT"))
+    {
+    	reattach_console();
+    }
 #endif
 
     // set the homedir for the OS first

--- a/src/SDL2screen.c
+++ b/src/SDL2screen.c
@@ -632,6 +632,18 @@ static void QLSDLUpdatePixelBuffer()
 	}
 }
 
+// Needed for the shader code
+void QLSDLWritePixels(uint32_t *pixelPtr32)
+{
+	uint8_t *emulatorScreenPtr = (uint8_t *)memBase + qlscreen.qm_lo;
+	uint8_t *emulatorScreenPtrEnd = emulatorScreenPtr + qlscreen.qm_len;
+
+	emulatorUpdatePixelBufferQL(pixelPtr32, emulatorScreenPtr,
+				    emulatorScreenPtrEnd);
+
+}
+
+
 void QLSDLRenderScreen(void)
 {
 	void *texture_buffer;


### PR DESCRIPTION
1. Added QLSDLWritePixels function to fix linker error when building shaders
2. Add a warning suppression so that the latest sdl-gpu builds 
3. Re-enabled shaders in build workflows
4. Added command line option to disable capture of Windows output
